### PR TITLE
Use fullscreen by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use simulation::Simulation;
 
 fn main() {
     let config = quarkstrom::Config {
-        window_mode: quarkstrom::WindowMode::Windowed(900, 900),
+        window_mode: quarkstrom::WindowMode::Fullscreen,
     };
     quarkstrom::run::<Renderer>(config);
 


### PR DESCRIPTION
Wayland does not allow querying or setting window positions, for some reason.  An easy workaround is to use fullscreen instead.  This prevents the application from crashing on startup.

Alternatively, the root cause can be fixed: https://github.com/DeadlockCode/quarkstrom/pull/2